### PR TITLE
Add no-mow project page and route homepage link to it

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
           </div>
 
           <div class="featured-project__image header-container">
-            <a href="https://www.washingtonpost.com/climate-solutions/interactive/2024/no-mow-lawn-care-tips/">
+            <a href="no-mow.html">
               <video class="header-image__mobile mobile" preload="auto" playsinline="" autoplay="" loop="" muted=""
                 autobuffer="false" poster="<%= require('./src/assets/nomow/promo-video.jpg') %>">
                 <source src="<%= require('./src/assets/nomow/promo-video.mp4') %>"
@@ -125,7 +125,7 @@
 
         <div class="featured-project__block"></div>
       </div>
-      <a href="https://wapo.st/4tq6tGr" class="featured-project__title">
+      <a href="no-mow.html" class="featured-project__title">
         <div class="featured-project__mickey-hand--desktop desktop"><svg xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 627.56 524.25">
             <defs>

--- a/src/project/no-mow.html
+++ b/src/project/no-mow.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <style>
+    html {
+      visibility: hidden;
+      opacity: 0;
+    }
+  </style>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Why you should let your grass grow | Frank Hulley-Jones</title>
+</head>
+
+<body>
+  <header class="logo logo-article">
+    <a class="logo__link--internet" href="index.html">
+      <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" viewBox="0 0 316 128"
+        xml:space="preserve">
+        <style>
+          .eye-white {
+            fill: #fff
+          }
+        </style>
+        <circle class="eye-white" cx="238" cy="64" r="44" />
+        <circle class="eye-white" cx="78" cy="64" r="44" />
+        <path id="frames"
+          d="M306 22h-19.7C274.5 8.5 257.3 0 238 0c-19.2 0-36.4 8.5-48.1 21.8C182.1 14.5 170.6 10 158 10s-24.1 4.5-31.9 11.8C114.4 8.5 97.2 0 78 0 58.7 0 41.5 8.5 29.7 22H10C4.5 22 0 26.5 0 32s4.5 10 10 10h7.9C15.4 48.9 14 56.3 14 64c0 35.3 28.7 64 64 64s64-28.7 64-64c0-8.6-1.7-16.8-4.8-24.3C140 34.6 147.8 30 158 30s18 4.6 20.8 9.7c-3.1 7.5-4.8 15.7-4.8 24.3 0 35.3 28.7 64 64 64s64-28.7 64-64c0-7.7-1.4-15.1-3.9-22h7.9c5.5 0 10-4.5 10-10s-4.5-10-10-10zM78 108c-24.3 0-44-19.7-44-44s19.7-44 44-44 44 19.7 44 44-19.7 44-44 44zm160 0c-24.3 0-44-19.7-44-44s19.7-44 44-44 44 19.7 44 44-19.7 44-44 44z"
+          fill="#121212" />
+      </svg>
+    </a>
+  </header>
+
+  <div class="article">
+    <div class="header wrapper">
+      <div class="header-container">
+        <video class="header-image__mobile mobile" preload="auto" playsinline autoplay loop muted
+          poster="<%= require('../../src/assets/nomow/promo-video.jpg') %>">
+          <source src="<%= require('../../src/assets/nomow/promo-video.mp4') %>" type="video/mp4" />
+        </video>
+        <video class="header-image__desktop desktop" preload="auto" playsinline autoplay loop muted
+          poster="<%= require('../../src/assets/nomow/promo-video.jpg') %>">
+          <source src="<%= require('../../src/assets/nomow/promo-video.mp4') %>" type="video/mp4" />
+        </video>
+      </div>
+    </div>
+
+    <div class="introduction wrapper">
+      <div class="item grid">
+        <div class="information grid__1-4">
+          <div class="information__type">
+            <div class="information__meta">Type: </div>
+            <div class="information__data">Interactive Feature</div>
+          </div>
+          <div class="information__client">
+            <div class="information__meta">Client: </div>
+            <div class="information__data">The Washington Post</div>
+          </div>
+          <div class="information__year">
+            <div class="information__meta">Year: </div>
+            <div class="information__data">2024</div>
+          </div>
+          <div class="information__role">
+            <div class="information__meta">Role: </div>
+            <div class="information__data">Placeholder role text — edit me</div>
+          </div>
+        </div>
+
+        <h1 class="headline grid__1-3">Why you should let your grass grow</h1>
+        <p class="description grid__3-4">This is placeholder copy for the project introduction. You can replace this paragraph with your final summary of the concept, process, and outcome.</p>
+      </div>
+    </div>
+
+    <div class="article-content wrapper">
+      <div class="image-content image-content__one">
+        <div class="paragraph paragraph__full paragraph__one">
+          <h2>Section heading placeholder</h2>
+          <p>
+            Placeholder body copy. Add your narrative, supporting detail, and any notes about research, design
+            decisions, and implementation details. This section is intentionally simple so it is easy to edit later.
+          </p>
+          <p>
+            Add as many paragraphs, images, or videos as needed.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/src/project/no-mow.js
+++ b/src/project/no-mow.js
@@ -1,0 +1,2 @@
+require("normalize.css/normalize.css");
+require("../styles/index.scss");

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -10,6 +10,7 @@ module.exports = {
         ukelection: "./src/project/uk-election.js",
         tweenmax: "./src/assets/TweenMax.min.js",
         hellogoogle: "./src/onepage/hello-google.js",
+        nomow: "./src/project/no-mow.js",
     },
     devServer: {
         port: 8080,
@@ -102,6 +103,12 @@ module.exports = {
             inject: true,
             chunks: ["hellogoogle"],
             filename: "hello-google.html",
+        }),
+        new HtmlWebpackPlugin({
+            template: "./src/project/no-mow.html",
+            inject: true,
+            chunks: ["nomow"],
+            filename: "no-mow.html",
         }),
     ],
 };

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -17,6 +17,7 @@ module.exports = {
         ukelection: "./src/project/uk-election.js",
         tweenmax: "./src/assets/TweenMax.min.js",
         hellogoogle: "./src/onepage/hello-google.js",
+        nomow: "./src/project/no-mow.js",
     },
     output: {
         filename: "[name].[contenthash:20].js",
@@ -99,6 +100,12 @@ module.exports = {
             inject: "body",
             chunks: ["hellogoogle"],
             filename: "hello-google.html",
+        }),
+        new HtmlWebpackPlugin({
+            template: "./src/project/no-mow.html",
+            inject: "body",
+            chunks: ["nomow"],
+            filename: "no-mow.html",
         }),
         new MiniCssExtractPlugin({
             filename: "styles.[contenthash].css", // Extract CSS into separate files with content hash


### PR DESCRIPTION
### Motivation
- Provide an internal project page for “Why you should let your grass grow” so the homepage link opens an in-repo page instead of an external URL.
- Keep the new page consistent with the other project pages (hero media, metadata block, editable content) so it is easy to edit and build with the existing webpack setup.

### Description
- Added a new project page template `src/project/no-mow.html` that includes mobile and desktop hero video elements and placeholder metadata/content matching the site’s article layout.
- Added a tiny entry script `src/project/no-mow.js` to load shared styles for the page via `require("../styles/index.scss")` and `normalize.css`.
- Updated `index.html` to point the featured image and title links for the “Why you should let your grass grow” feature to `no-mow.html` instead of the external Washington Post URL.
- Wired the page into the build by adding a `nomow` entry and an `HtmlWebpackPlugin` target in both `webpack.dev.js` and `webpack.prod.js` so `no-mow.html` is emitted and served like the other project pages.
- Committed changes on branch `style-tweaks-0226` with the message `Add no-mow project page and homepage routing`.

### Testing
- Ran `npm run build` successfully; webpack completed the build (noting existing asset-size warnings) and emitted `no-mow.html` into the build output.
- Ran the dev server with `npm run dev` and verified compilation succeeded and the site served correctly.
- Automated navigation test using Playwright confirmed clicking the homepage featured project navigates to `/no-mow.html` and a screenshot was captured; this manual/dev verification passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bbca10fb4832eb0afd6a758b393cd)